### PR TITLE
Adding base support for VMDK to Exhume Body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,8 @@ dependencies = [
  "glob",
  "log",
  "regex",
- "strum",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -183,12 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +194,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "log"
@@ -278,38 +279,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustversion"
+name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,8 @@ dependencies = [
  "flate2",
  "glob",
  "log",
+ "regex",
+ "strum",
 ]
 
 [[package]]
@@ -179,6 +181,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "humantime"
@@ -223,6 +231,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,10 +278,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ flate2 = "1.0.25"
 glob = "0.3.1"
 clap = "4.0"
 clap-num = "1.1.1"
-strum = { version = "0.27.1", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 regex = "1.11.1"
 
 log = "0.4.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ flate2 = "1.0.25"
 glob = "0.3.1"
 clap = "4.0"
 clap-num = "1.1.1"
+strum = { version = "0.27.1", features = ["derive"] }
+regex = "1.11.1"
 
 log = "0.4.25"
 env_logger = "0.11.6"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ The exhume Body module is part of the exhume toolkit and is allowing you to exam
 The current supported formats are:
 - RAW
 - EWF
+- VMDK
+
+VMFSSparse (ESXi snapshots, delta files, linked clones) and full physical disk or partition-wide VMDK volumes are not supported.
 
 ## 📄 Getting started
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod ewf;
 pub mod raw;
+pub mod vmdk;
 use ewf::EWF;
 use log::{error, info};
 use raw::RAW;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ impl Body {
     pub fn get_sector_size(&self) -> u16 {
         match &self.format {
             BodyFormat::EWF { image, .. } => image.get_sector_size(),
-            BodyFormat::VMDK { image,.. } => image.get_sector_size() as u16,
+            BodyFormat::VMDK { image, .. } => image.get_sector_size() as u16,
             BodyFormat::RAW { .. } => 512,
             // All other compatible formats will be handled here.
         }
@@ -137,7 +137,7 @@ impl Body {
     pub fn format_description(&self) -> &str {
         match &self.format {
             BodyFormat::EWF { description, .. } => description,
-            BodyFormat::VMDK { description , ..} => description,
+            BodyFormat::VMDK { description, .. } => description,
             BodyFormat::RAW { description, .. } => description,
             // Handle additional formats here.
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,21 @@ fn process_file(file_path: &str, format: &str, size: &u64, offset: &u64) {
             info!("Sector size: {:?}", reader.get_sector_size());
             debug!("------------------------------------------------------------");
         }
+        "vmdk" => {
+            info!("Processing the file '{}' in 'vmdk' format...", file_path);
+            reader = Body::new_from(file_path.to_string(), format, Some(*offset));
+            info!("------------------------------------------------------------");
+            info!("Selected format: VMDK");
+            info!("Description: VMDK (Virtual Machine Disk) file.");
+            debug!("------------------------------------------------------------");
+        }
         "auto" => {
             info!("Processing the file '{}' in 'auto' format...", file_path);
             reader = Body::new_from(file_path.to_string(), format, Some(*offset));
         }
         _ => {
             error!(
-                "Invalid format '{}'. Supported formats are 'raw', 'ewf', and 'auto'.",
+                "Invalid format '{}'. Supported formats are 'raw', 'ewf', 'vmdk', and 'auto'.",
                 format
             );
             std::process::exit(1);
@@ -65,7 +73,7 @@ fn main() {
                 .long("format")
                 .value_parser(value_parser!(String))
                 .required(false)
-                .help("The format of the file, either 'raw', 'ewf', or 'auto'."),
+                .help("The format of the file, either 'raw', 'ewf', 'vmdk' or 'auto'."),
         )
         .arg(
             Arg::new("size")

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -624,8 +624,6 @@ impl VMDKSparseExtentMetadata {
                     .map_err(|e| format!("Error reading sparse extent file: {}", e))?;
                 grain_table_entries.push(u32::from_le_bytes(grain_buf));
             }
-            debug!("Grain table entries: {:?}", grain_table_entries);
-            break;
         }
         Ok(VMDKSparseExtentMetadata {
             header: header.clone(),
@@ -670,7 +668,7 @@ fn read_sparse_extent(
                 .get(grain as usize)
                 .ok_or(io::Error::new(
                     io::ErrorKind::Other,
-                    "Grain directory entry not found",
+                    format!("Grain directory entry not found: {}", grain),
                 ))?;
         if sector_number == 0 {
             // The grain is sparse

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -409,6 +409,9 @@ enum VMDKDiskType {
     /// TODO: Implement parsing for the 2 possible names
     #[strum(serialize = "2GbMaxExtentFlat")]
     TwoGbMaxExtentFlat,
+    /// Same as TwoGbMaxExtentFlat, this exists to take into account the 2 possible names
+    #[strum(serialize = "twoGbMaxExtentFlat")]
+    TwoGbMaxExtentFlatAlt,
     /// The disk is split into sparse (dynamic-size) extents of maximum 2 GB.
     /// The extents consists of VMDK sparse extent data files.
     /// 
@@ -417,6 +420,9 @@ enum VMDKDiskType {
     /// * VMDK sparse data extent files (<name>-s.vmdk), where is contains a decimal value starting with 1.
     #[strum(serialize = "2GbMaxExtentSparse")]
     TwoGbMaxExtentSparse,
+    /// Same as TwoGbMaxExtentSparse, this exists to take into account the 2 possible names
+    #[strum(serialize = "twoGbMaxExtentSparse")]
+    TwoGbMaxExtentSparseAlt,
     /// Descriptor file with arbitrary extents , used to mount v2i-format.
     Custom,
     /// The disk uses a full physical disk device.

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -718,7 +718,7 @@ fn read_sparse_extent(
                 if upper_bound > bytes_read {
                     upper_bound = bytes_read;
                 }
-                buf[read_size..read_size + upper_bound]
+                buf[read_size + additional_offset as usize..read_size + upper_bound]
                     .copy_from_slice(&decompressed_buf[additional_offset as usize..upper_bound]);
                 read_size += upper_bound - additional_offset as usize;
             } else {

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -1,0 +1,593 @@
+//! This module contains functionality for reading VMDK volumes.
+//! 
+//! # Known Limitations
+//! 
+//! For the moment VMDK descriptor files not written in UTF-8 encoding are not supported.
+
+use std::{collections::HashMap, fs::{self, File}, str::FromStr, sync::LazyLock};
+
+use regex::Regex;
+use strum::EnumString;
+
+const SECTOR_SIZE: u16 = 512;
+const DESCRIPTOR_FILE_SIGNATURE: &'static str = "# Disk DescriptorFile";
+const DESCRIPTOR_FILE_EXTENT_SECTION_SIGNATURE: &'static str = "# Extent description";
+const DESCRIPTOR_FILE_CHANGE_TRACKING_SECTION_SIGNATURE: &'static str  = "# Change Tracking File";
+const DESCRIPTOR_FILE_DISK_DATABASE_SECTION_SIGNATURE: &'static str = "# The Disk Data Base";
+
+/// Represents the character encoding used for the descriptor file.
+/// 
+/// See also: https://github.com/libyal/libvmdk/blame/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#211-encodings
+#[derive(Debug, EnumString, PartialEq)]
+enum VMDKEncoding {
+    /// UTF-8 encoding
+    #[strum(serialize = "UTF-8")]
+    Utf8,
+    /// Big5 assumed to be equivalent to Windows codepage 950
+    #[strum(serialize = "Big5")]
+    Big5,
+    /// GBK assumed to be equivalent to Windows codepage 936
+    /// Seen in VMware editions used for Windows Chinese editions
+    #[strum(serialize = "GBK")]
+    Gbk,
+    /// Shift_JIS assumed to be equivalent to Windows codepage 932
+    /// Seen in VMWare Workstation for Windows, Japanese edition
+    #[strum(serialize = "Shift_JIS")]
+    ShiftJis,
+    /// Windows codepage 1252
+    /// Seen in VMWare Player 9 descriptor file uncertain when this was introduced.
+    #[strum(serialize = "windows-1252")]
+    Windows1252,
+}
+
+/// Represents a VMDK header section in a VMDK descriptor file.
+struct VMDKHeader {
+    /// The VMDK version number, must be 1, 2 or 3.
+    version: u8,
+    /// Encoding of the descriptor file
+    encoding: VMDKEncoding,
+    /// Content identifier _ A random 32-bit value updated the first time the content of the virtual disk is modified after the virtual disk is opened.
+    cid: u32,
+    /// The content identifier of the parent.
+    /// A 32-bit value identifying the parent content. A value of 'ffffffff' (-1) represents no parent content.
+    parent_cid: u32,
+    /// Only seen values are "no"
+    is_native_snapshot: Option<bool>,
+    /// The disk type
+    create_type: VMDKDiskType,
+    /// Contains the path to the parent image.
+    /// This value is only present if the image is a differential image (delta link).
+    parent_file_name_hint: Option<String>,
+}
+
+impl TryFrom<HashMap<String, String>> for VMDKHeader {
+    type Error = String;
+
+    fn try_from(value: HashMap<String, String>) -> Result<Self, Self::Error> {
+        // Error handling here may be too strict, consider more flexible parsing with warnings instead.
+        // In our use case, only the information related to the extent is really needed.
+        // Just replace error mapping with a default.
+        let version = value.get("version")
+            .ok_or("version not found in header")?.parse()
+            .map_err(|_| "invalid version in header")?;
+        let encoding = value.get("encoding")
+            .ok_or("encoding not found in header")?.parse()
+            .map_err(|_| "invalid encoding in header")?;
+        let cid = u32::from_str_radix(
+            value.get("CID").ok_or("CID not found in header")?.as_str(),
+            16
+        ).map_err(|_| "invalid CID in header")?;
+        let parent_cid = u32::from_str_radix(
+            value.get("parentCID").ok_or("parentCID not found in header")?.as_str(),
+            16
+        ).map_err(|_| "invalid parent CID in header")?;
+        let is_native_snapshot = value.get("isNativeSnapshot")
+            .map(|s| s.as_str() == "yes");
+        let create_type = value.get("createType")
+           .ok_or("createType not found in header")?.parse()
+           .map_err(|_| "invalid createType in header")?;
+        let parent_file_name_hint = value.get("parentFileNameHint")
+           .map(|s| s.to_string());
+
+        Ok(VMDKHeader {
+            version,
+            encoding,
+            cid,
+            parent_cid,
+            is_native_snapshot,
+            create_type,
+            parent_file_name_hint,
+        })
+    }
+}
+
+/// Access mode for an extent.
+#[derive(Debug, EnumString, PartialEq)]
+#[strum(serialize_all = "UPPERCASE")]
+enum VMDKExtentAccessMode {
+    /// No access
+    NoAccess,
+    /// Read-only access
+    RdOnly,
+    /// Read-write access
+    Rw,
+}
+
+#[derive(Debug, EnumString, PartialEq)]
+#[strum(serialize_all = "UPPERCASE")]
+enum VMDKExtentType {
+    /// RAW extent data file
+    /// Seen in VMWare Player 9 to be also used for devices on Windows
+    Flat,
+    /// VMDK sparse extent data file
+    Sparse,
+    /// Sparse extent that consists of 0-byte values
+    Zero,
+    /// RAW extent data file
+    Vmfs,
+    /// COWD sparse extent data file
+    VmfsSparse,
+    VmfsRdm,
+    VmfsRaw,
+}
+
+/// The extent descriptor allows to locate data within the extent files of the virtual disk.
+struct VMDKExtentDescriptor {
+    /// Access mode for the extent
+    access_mode: VMDKExtentAccessMode,
+    /// Number of sectors in the extent
+    sector_number: u64,
+    /// The type of the extent
+    extent_type: VMDKExtentType,
+    /// The name of the extent file. Specified if the extent type is different from flat
+    extent_file_name: Option<String>,
+    /// The start sector of the extent in the parent image. Optional and defaults to 0.
+    extent_start_sector: Option<u64>,
+    /// Only specified in some cases regarding Windows systems
+    partition_uuid: Option<String>,
+    /// Only specified in some cases regarding Windows systems
+    device_identifier: Option<String>,
+}
+
+
+impl FromStr for VMDKExtentDescriptor {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // We use a LazyLock cell to ensure that the regex is compiled only once, ensuring better performance in a thread-safe manner 
+        // (required to be inserted into a static variable).
+        static EXTENT_DESCRIPTOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"^(\w+)\s+(\d+)\s+(\w+)\s*"?([\w\-\.\/ ]+)?"?\s*(\d+)?\s*([\w\-\.\/ ]+)?\s*([\w\-\.\/ ]+)?$"#).unwrap()
+        });
+        let captures = EXTENT_DESCRIPTOR_REGEX.captures(s).ok_or_else(|| {
+            format!("Invalid extent descriptor format: {}", s)
+        })?;
+        Ok(Self {
+            // Match group 1 to 3 will always contain a value at this stage, we can safely unwrap these values.
+            access_mode: VMDKExtentAccessMode::from_str(captures.get(1).unwrap().as_str())
+                .map_err(|_| format!("Invalid access mode in extent description: {}", captures.get(1).unwrap().as_str()))?, 
+            sector_number: captures.get(2).unwrap().as_str().parse()
+                .map_err(|_| format!("Invalid sector number in extent description: {}", captures.get(2).unwrap().as_str()))?,
+            extent_type: VMDKExtentType::from_str(captures.get(3).unwrap().as_str())
+                .map_err(|_| format!("Invalid extent type in extent description: {}", captures.get(3).unwrap().as_str()))?,
+            extent_file_name: captures.get(4).map(|m| m.as_str().to_string()),
+            // Maybe silently ignoring a parse error is not the best solution here
+            extent_start_sector: captures.get(5).map(|m| m.as_str().parse::<u64>().unwrap_or(0)),
+            partition_uuid: captures.get(6).map(|m| m.as_str().to_string()),
+            device_identifier: captures.get(7).map(|m| m.as_str().to_string()),
+        })
+    }
+}
+
+/// The change tracking file section was introduced in version 3 and seems to allow definition of a file log of changes made to the virtual disk.
+struct VMDKChangeTrackingSection {
+    /// Path of the change tracking file.
+    change_track_path: String,
+}
+
+#[derive(Debug, EnumString, PartialEq)]
+enum VMDKDiskAdapterType {
+    #[strum(serialize = "ide")]
+    Ide,
+    #[strum(serialize = "buslogic")]
+    BusLogic,
+    #[strum(serialize = "lsilogic")]
+    LSILogic,
+    #[strum(serialize = "legacyESX")]
+    LegacyESX,
+}
+
+struct VMDKDiskDatabase {
+    /// Most encountered value is true
+    ddb_deletable: Option<bool>,
+    /// The virtual hardware version
+    /// For VMWare Player and Workstation this seems to correspond with the application version
+    ddb_virtual_hw_version: Option<String>,
+    /// The long content identifier
+    /// 128-bit base16 encoded value, without spaces
+    ddb_long_content_id: Option<String>,
+    /// Unique identifier
+    /// 128-bit base16 encoded value, with spaces between bytes
+    ddb_uuid: Option<String>,
+    /// The number of cylinders
+    ddb_geometry_cylinders: Option<u32>,
+    /// The number of heads
+    ddb_geometry_heads: Option<u32>,
+    /// The number of sectors
+    ddb_geometry_sectors: Option<u32>,
+    /// The number of cylinders as reported by the BIOS
+    ddb_geometry_bios_cylinders: Option<u32>,
+    /// The number of heads as reported by the BIOS
+    ddb_geometry_bios_heads: Option<u32>,
+    /// The number of sectors as reported by the BIOS
+    ddb_geometry_bios_sectors: Option<u32>,
+    /// The disk adapter type
+    ddb_adapter_type: Option<VMDKDiskAdapterType>,
+    /// String containing the version of the installed VMWare tools
+    ddb_tools_version: Option<String>,
+    /// Generally set to "1"
+    ddb_thin_provisioned: Option<bool>,
+}
+
+impl TryFrom<HashMap<String, String>> for VMDKDiskDatabase {
+    type Error = String;
+
+    fn try_from(value: HashMap<String, String>) -> Result<Self, Self::Error> {
+        let ddb_deletable = value.get("ddb.deletable").map(|s| s == "true");
+        let ddb_virtual_hw_version = value.get("ddb.virtualHWVersion").map(|s| s.to_string());
+        let ddb_long_content_id = value.get("ddb.longContentId").map(|s| s.to_string());
+        let ddb_uuid = value.get("ddb.uuid").map(|s| s.to_string());
+        let ddb_geometry_cylinders = value.get("ddb.geometry.cylinders").map(|s| s.parse().unwrap_or(0));
+        let ddb_geometry_heads = value.get("ddb.geometry.heads").map(|s| s.parse().unwrap_or(0));
+        let ddb_geometry_sectors = value.get("ddb.geometry.sectors").map(|s| s.parse().unwrap_or(0));
+        let ddb_geometry_bios_cylinders = value.get("ddb.geometry.biosCylinders").map(|s| s.parse().unwrap_or(0));
+        let ddb_geometry_bios_heads = value.get("ddb.geometry.biosHeads").map(|s| s.parse().unwrap_or(0));
+        let ddb_geometry_bios_sectors = value.get("ddb.geometry.biosSectors").map(|s| s.parse().unwrap_or(0));
+        let ddb_adapter_type = if let Some(s) = value.get("ddb.adapterType") {
+            VMDKDiskAdapterType::from_str(s).ok()
+        } else {
+            None
+        };
+        let ddb_tools_version = value.get("ddb.toolsVersion").map(|s| s.to_string());
+        let ddb_thin_provisioned = value.get("ddb.thinProvisioned").map(|s| s == "true");
+        Ok(Self {
+            ddb_deletable,
+            ddb_virtual_hw_version,
+            ddb_long_content_id,
+            ddb_uuid,
+            ddb_geometry_cylinders,
+            ddb_geometry_heads,
+            ddb_geometry_sectors,
+            ddb_geometry_bios_cylinders,
+            ddb_geometry_bios_heads,
+            ddb_geometry_bios_sectors,
+            ddb_adapter_type,
+            ddb_tools_version,
+            ddb_thin_provisioned,
+        })
+    }
+}
+
+/// Represents a VMDK descriptor file.
+/// 
+/// As defined at: https://github.com/libyal/libvmdk/blob/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#2-the-descriptor-file
+struct VMDKDescriptorFile {
+    /// The VMDK header read from the descriptor file.
+    header: VMDKHeader,
+    /// The VMDK extent descriptions read from the descriptor file.
+    extent_descriptions: Vec<VMDKExtentDescriptor>,
+    /// The VMDK change tracking file read from the descriptor file.
+    change_tracking_file: Option<VMDKChangeTrackingSection>,
+    /// The VMDK disk database file read from the descriptor file.
+    disk_database: Option<VMDKDiskDatabase>,
+}
+
+/// Returns a keyword related to the section mention from the line recovered from the descriptor file.
+/// 
+/// Possible values returned are:
+/// * "header" if the line starts VMDK header
+/// * "extent" if the line starts VMDK extent section
+/// * "ddb" if the line starts VMDK disk database section
+/// * "change_tracking" if the line starts VMDK change tracking section
+/// * None if the line does not correspond to any known section type
+fn get_descriptor_section(line: &str) -> Option<&'static str> {
+    if line.starts_with("#") {
+        match line {
+            DESCRIPTOR_FILE_SIGNATURE => return Some("header"),
+            DESCRIPTOR_FILE_EXTENT_SECTION_SIGNATURE => return Some("extent"),
+            DESCRIPTOR_FILE_DISK_DATABASE_SECTION_SIGNATURE => return Some("ddb"),
+            DESCRIPTOR_FILE_CHANGE_TRACKING_SECTION_SIGNATURE => return Some("change_tracking"),
+            _ => return None,
+        }
+    }
+    None
+}
+
+
+/// Parses a key-value pair from the given line.
+/// 
+/// Returns None if the line does not match the expected key-value format.
+fn parse_key_value_pair(line: &str) -> Option<(&str, &str)> {
+    // We use a LazyLock cell to ensure that the regex is compiled only once, ensuring better performance in a thread-safe manner 
+    // (required to be inserted into a static variable).
+    static KEY_VALUE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^([\w\.]+)\s*=\s*"?([^"]*)"?$"#).unwrap());
+    let captures = KEY_VALUE_REGEX.captures(line);
+    if let Some(captures) = captures {
+        Some((captures.get(1).unwrap().as_str(), captures.get(2).unwrap().as_str()))
+    } else {
+        None
+    }
+}
+
+impl FromStr for VMDKDescriptorFile {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Iterate over the lines of the string slice
+        let mut lines = s.lines();
+        let mut line = lines.next();
+        let mut current_section = "";
+        let mut file_header_hashmap = HashMap::new();
+        let mut extent_descriptions = Vec::new();
+        let mut ddb_hashmap = HashMap::new();
+        let mut change_track_path = None;
+
+        // We have to look for sections specified as comments
+        while line.is_some() {
+            let unwrapped_line = line.unwrap().trim(); // This should be safe to unwrap here as we verified we have Some already
+            if unwrapped_line.starts_with("#") {
+                current_section = get_descriptor_section(unwrapped_line).unwrap_or(current_section);
+            } else {
+                match current_section { 
+                    "header" => {
+                        let parsed_pair = parse_key_value_pair(unwrapped_line);
+                        if let Some((key, value)) = parsed_pair {
+                            file_header_hashmap.insert(key.to_string(), value.to_string());
+                        }
+                    },
+                    "extent" => {
+                        let extent_descriptor = unwrapped_line.parse();
+                        if let Ok(extent_descriptor) = extent_descriptor {
+                            extent_descriptions.push(extent_descriptor);
+                        }
+                    },
+                    "ddb" => {
+                        let parsed_pair = parse_key_value_pair(unwrapped_line);
+                        if let Some((key, value)) = parsed_pair {
+                            ddb_hashmap.insert(key.to_string(), value.to_string());
+                        }
+                    },
+                    "change_tracking" => {
+                        let parsed_pair = parse_key_value_pair(unwrapped_line);
+                        if let Some((key, value)) = parsed_pair {
+                            if key == "changeTrackPath" {
+                                change_track_path = Some(value.to_string());
+                            }
+                        }
+                    },
+                    _ => {},
+                }
+            }
+            line = lines.next();
+        }
+
+        Ok(VMDKDescriptorFile {
+            header: VMDKHeader::try_from(file_header_hashmap)?,
+            extent_descriptions,
+            change_tracking_file: if let Some(change_track_path) = change_track_path {
+                Some(VMDKChangeTrackingSection {
+                    change_track_path,
+                })
+            } else {
+                None
+            },
+            disk_database: VMDKDiskDatabase::try_from(ddb_hashmap).ok(),
+        })
+    }
+}
+
+/// Represents a VMDK disk type.
+/// 
+/// As defined at: https://github.com/libyal/libvmdk/blame/main/documentation/VMWare%20Virtual%20Disk%20Format%20(VMDK).asciidoc#212-disk-type
+#[derive(Debug, EnumString, PartialEq)]
+#[strum(serialize_all = "camelCase")]
+enum VMDKDiskType {
+    /// The disk is split into fixed-size extents of maximum 2 GB.
+    /// The extents consists of RAW extent data files.
+    /// 
+    /// The 2GbMaxExtentFlat (or twoGbMaxExtentFlat) disk image consists of:
+    /// * a descriptor file
+    /// * RAW data extent files (<name>-f.vmdk), where is contains a decimal value starting with 1.
+    #[strum(serialize = "2GbMaxExtentFlat")]
+    TwoGbMaxExtentFlat,
+    /// The disk is split into sparse (dynamic-size) extents of maximum 2 GB.
+    /// The extents consists of VMDK sparse extent data files.
+    /// 
+    /// The 2GbMaxExtentSparse (or twoGbMaxExtentSparse) disk image consists of:
+    /// * a descriptor file
+    /// * VMDK sparse data extent files (<name>-s.vmdk), where is contains a decimal value starting with 1.
+    #[strum(serialize = "2GbMaxExtentSparse")]
+    TwoGbMaxExtentSparse,
+    /// Descriptor file with arbitrary extents , used to mount v2i-format.
+    Custom,
+    /// The disk uses a full physical disk device.
+    FullDevice,
+    /// The disk is a single RAW extent data file.
+    /// 
+    /// The monolithicFlat disk image consists of:
+    /// * a descriptor file
+    /// * RAW data extent file (<name>-f001.vmdk)
+    MonolithicFlat,
+    /// The disk is a single VMDK sparse extent data file.
+    /// 
+    /// The monolithicSparse disk image consists of:
+    /// * VMDK sparse data extent file (<name>.vmdk) also contains the descriptor file data.
+    MonolithicSparse,
+    /// The disk uses a full physical disk device, using access per partition.
+    PartitionedDevice,
+    /// The disk is a single compressed VMDK sparse extent data file.
+    StreamOptimized,
+    /// The disk is a single RAW extent data file.
+    /// This is similar to the "monolithicFlat".
+    /// 
+    /// The vmfs disk image consists of:
+    /// * a descriptor file
+    /// * RAW data extent file (<name>-flat.vmdk)
+    Vmfs,
+    /// The disk is a single RAW extent data file.
+    /// The disk is pre‐allocated on VMFS, with all blocks zeroed when created.
+    VmfsEagerZeroedThick,
+    /// The disk is a single RAW extent data file. The disk is pre‐allocated on VMFS, with blocks zeroed on first use.
+    VmfsPreallocated,
+    /// The disk uses a full physical disk device.
+    /// Special raw disk for ESXi hosts, pass through only mode.
+    VmfsRaw,
+    /// The disk uses a full physical disk device.
+    /// Also referred to as Raw Device Map (RDM).
+    #[strum(serialize = "vmfsRDM")]
+    VmfsRawDeviceMap,
+    /// The disk uses a full physical disk device.
+    /// Similar to the Raw Device Map (RDM), but sends SCSI commands to underlying hardware.
+    #[strum(serialize = "vmfsRDMP")]
+    VmfsPassthroughRawDeviceMap,
+    /// The disk is split into sparse (dynamic-size) extents.
+    /// The extents consists of COWD sparse extent data files.
+    /// Often used as a redo-log
+    /// 
+    /// The vmfsSparse disk image consists of:
+    /// * a descriptor file
+    /// * COWD sparse data extent files (<name>-delta.vmdk)
+    VmfsSparse,
+    /// The disk is split into sparse (dynamic-size) extents.
+    /// The extents consists of COWD sparse extent data files.
+    VmfsThin,
+}
+
+/// Represents a VMDK virtual disk.
+pub struct VMDK {
+    /// The descriptor file for the volume
+    descriptor_file: VMDKDescriptorFile,
+    /// List of the extent files for the volume
+    extent_files: Vec<File>,
+}
+
+impl VMDK {
+    /// Attempts to create a new VMDK object from the given file path.
+    /// The given file path must be a valid VMDK descriptor file.
+    /// 
+    /// # Errors
+    /// 
+    /// Throws an error if the file at the given path is not a valid VMDK descriptor file or if the specified extent files cannot be opened.
+    /// May also throw an error if the encountered extend files are of unrecognized types.
+    pub fn new(file_path: &str) -> Result<VMDK, String> {
+        // Open the descriptor file and retrieve string contents
+        let descriptor_file_contents = fs::read_to_string(file_path)
+           .map_err(|e| format!("Error reading descriptor file: {}", e))?;
+
+        // Parse the descriptor file into a VMDKDescriptorFile object
+        let descriptor_file: VMDKDescriptorFile = descriptor_file_contents.parse()
+           .map_err(|e| format!("Error parsing descriptor file: {}", e))?;
+        
+        // Try to open all the identified extent files and add them to the VMDK object
+        let mut extent_files_iter = descriptor_file.extent_descriptions
+            .iter()
+            .filter_map(|extent| {
+                if let Some(ref extent_file_name) = extent.extent_file_name {
+                    Some(File::open(extent_file_name)
+                    .map_err(|e| format!("Error opening extent file {}: {}", extent_file_name, e)))
+                } else {
+                    None
+                }
+            });
+        
+        if extent_files_iter.any(|e| e.is_err()) {
+            let mut err = String::from("Error opening one or more extent files:");
+            for err_msg in extent_files_iter.filter_map(|e| e.err()) {
+                err.push_str(&format!("\n- {}", err_msg));
+            }
+            return Err(err);
+        } else {
+            // Unwrapping should be safe here as we eliminated None values and checked that no error occurred while opening extent files
+            let extent_files = extent_files_iter.map(|f| f.unwrap()).collect();
+            return Ok(VMDK {
+                descriptor_file,
+                extent_files,
+            });
+        }
+    }
+
+    pub fn print_info(&self) {
+    }
+
+    pub fn get_sector_size(&self) -> u16 {
+        SECTOR_SIZE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_key_value_pair() {
+        assert_eq!(
+            parse_key_value_pair("key1 = value1"),
+            Some(("key1", "value1"))
+        );
+        assert_eq!(
+            parse_key_value_pair("key2 = value2 with spaces"),
+            Some(("key2", "value2 with spaces"))
+        );
+        assert_eq!(
+            parse_key_value_pair("key3 = \"with quotes\""),
+            Some(("key3", "with quotes"))
+        );
+        assert_eq!(
+            parse_key_value_pair("key3 = \"with non-ascii çàù\""),
+            Some(("key3", "with non-ascii çàù"))
+        );
+        assert_eq!(parse_key_value_pair("key4"), None);
+        assert_eq!(
+            parse_key_value_pair("key.with.periods = aaa"),
+            Some(("key.with.periods", "aaa"))
+        );
+    }
+
+    #[test]
+    fn test_parse_descriptor_data() {
+        let descriptor_data = r#"
+# Disk DescriptorFile
+version=1
+CID=123a5678
+parentCID=ffffffff
+createType="2GbMaxExtentSparse"
+encoding="UTF-8"
+isNativeSnapshot="no"
+
+# Extent description
+RW 4192256 ZERO
+
+# The Disk Data Base
+# DDB
+
+ddb.virtualHWVersion = "4"
+ddb.geometry.cylinders = "16383"
+ddb.geometry.heads = "16"
+ddb.geometry.sectors = "63"
+ddb.adapterType = "ide"
+ddb.toolsVersion = "0"
+"#;
+
+        let descriptor = descriptor_data.parse::<VMDKDescriptorFile>();
+        //assert_eq!(descriptor.err(), None);
+        assert!(descriptor.is_ok());
+        let descriptor = descriptor.unwrap();
+        assert_eq!(descriptor.header.create_type, VMDKDiskType::TwoGbMaxExtentSparse);
+        assert_eq!(descriptor.header.cid, 0x123a5678);
+        assert_eq!(descriptor.header.parent_cid, 0xffffffff);
+        assert_eq!(descriptor.header.is_native_snapshot, Some(false));
+        assert_eq!(descriptor.extent_descriptions.get(0).unwrap().access_mode, VMDKExtentAccessMode::Rw);
+        assert_eq!(descriptor.extent_descriptions.get(0).unwrap().sector_number, 4192256);
+        assert_eq!(descriptor.extent_descriptions.get(0).unwrap().extent_type, VMDKExtentType::Zero);
+        assert_eq!(descriptor.disk_database.unwrap().ddb_geometry_cylinders, Some(16383));
+    }
+}

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -628,8 +628,7 @@ impl VMDK {
         if let Some(ref disk_database) = self.descriptor_file.disk_database {
             if let Some(sectors) = disk_database.ddb_geometry_sectors {
                 // Maybe we shouldn't rely on this information and rather use the number of sectors from the extent descriptions
-                info!("  Disk Size: {} sectors", sectors);
-                info!("  Disk Size: {} bytes", sectors * SECTOR_SIZE);
+                info!("  Disk sectors: {} sectors", sectors);
             }
             if let Some(ref tools) = disk_database.ddb_tools_version {
                 info!("  Guest tools Version: {}", tools);

--- a/src/vmdk/mod.rs
+++ b/src/vmdk/mod.rs
@@ -25,10 +25,10 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 const SECTOR_SIZE: u64 = 512;
-const DESCRIPTOR_FILE_SIGNATURE: &'static str = "# Disk DescriptorFile";
-const DESCRIPTOR_FILE_EXTENT_SECTION_SIGNATURE: &'static str = "# Extent description";
-const DESCRIPTOR_FILE_CHANGE_TRACKING_SECTION_SIGNATURE: &'static str = "# Change Tracking File";
-const DESCRIPTOR_FILE_DISK_DATABASE_SECTION_SIGNATURE: &'static str = "# The Disk Data Base";
+const DESCRIPTOR_FILE_SIGNATURE: &str = "# Disk DescriptorFile";
+const DESCRIPTOR_FILE_EXTENT_SECTION_SIGNATURE: &str = "# Extent description";
+const DESCRIPTOR_FILE_CHANGE_TRACKING_SECTION_SIGNATURE: &str = "# Change Tracking File";
+const DESCRIPTOR_FILE_DISK_DATABASE_SECTION_SIGNATURE: &str = "# The Disk Data Base";
 
 // Flags used in sparse extent file headers.
 const _FLAG_VALID_NEWLINE_DETECTION_TEST: u32 = 0x00000001;


### PR DESCRIPTION
# Description of the feature

This pull request implements a new module for Exhume Body to support VMDK files. As of today, this module supports reading multiple VMDK extent types:

* Flat (monolithic or split)
* Sparse for VMware Workstation (monolithic or split)
* StreamOptimized (OVF and OVA exchange formats)

The following formats are not supported:

* Full physical disk or partition-wide VMDK
* VMFSSparse (sparse files for ESXi, including linked clones and snapshots): more samples are needed to write a reader

This module has been tested with all the formats listed as supported, notably with Exhume Partitions and Body command lines. Any unsupported format should trigger a useful error message indicating that it is not readable.

Moreover, I added an option in the disk type to allow auto detection of VMDK files and manual setting on the command line.

# Code considerations

All structures related to metadata implement the traits Clone, Debug, Serialize, and Deserialize to allow future features to retrieve metadata related to the VMDK files as JSON. As I don't know how this should be implemented, I didn't change the visibility of the metadata structures. They can be made public without an itch but fields should remain private because of format assumptions made around some unwraps.

The code is fully documented in rust doc.

The top struct is VMDK which implements the Read and Seek traits to be able to be treated as a Body. Any complexity related to VMDK file organization or type is shadowed behind generic read and seek functions that only provide an interface to navigate as if the disk was a single file with data in sequential order.

Some constants and parameters from the structs containing metadata are unused by the code, although they can be serialized and displayed. These values are not of any use at this stage for reading the files themselves but can be used by the end user in their investigations.

# Improvements

The code can be improved in several ways:

* An actual way of serializing the metadata should be implemented crate-wide
* The VMFSSparse format is an important part of VMDK we should support
* The crate organization could be reviewed to use the `mod_name.rs` and `mod_name/submod.rs` scheme instead of `mod_name/mod.rs` to facilitate the changes in several files at once (see the Rust Book for more details: https://doc.rust-lang.org/book/ch07-05-separating-modules-into-different-files.html#alternate-file-paths)